### PR TITLE
Register event-poll slash command to the target guild

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,12 +1,23 @@
 export {
+  ApplicationCommandOptionTypes,
+  ApplicationCommandTypes,
+  Collection,
+  createApplicationCommand,
   createBot,
   createEventHandlers,
+  InteractionTypes,
   sendMessage,
   startBot,
+  upsertApplicationCommands,
 } from "https://deno.land/x/discordeno@13.0.0-rc35/mod.ts";
 
 export type {
+  ApplicationCommandOption,
   Bot,
+  CreateApplicationCommand,
   EventHandlers,
+  Guild,
+  Interaction,
+  MakeRequired,
   Message,
 } from "https://deno.land/x/discordeno@13.0.0-rc35/mod.ts";

--- a/src/command/commander.ts
+++ b/src/command/commander.ts
@@ -1,0 +1,31 @@
+import type {
+  Bot,
+  CreateApplicationCommand,
+  MakeRequired,
+} from "../../deps.ts";
+
+import { upsertApplicationCommands } from "../../deps.ts";
+
+import { Loggable } from "../logger/mod.ts";
+
+const updateGuildCommands = async (
+  bot: Bot,
+  logger: Loggable,
+): Promise<Error | void> => {
+  const guildCommands: MakeRequired<CreateApplicationCommand, "name">[] = [];
+
+  if (guildCommands.length > 0) {
+    for (const guildId of bot.activeGuildIds) {
+      try {
+        await upsertApplicationCommands(bot, guildCommands, guildId);
+      } catch (err) {
+        logger.error("failed to register guild commands", err);
+        return Promise.reject(err);
+      }
+    }
+  }
+
+  return Promise.resolve();
+};
+
+export { updateGuildCommands };

--- a/src/command/eventpoll/eventpoll.ts
+++ b/src/command/eventpoll/eventpoll.ts
@@ -1,0 +1,42 @@
+import type {
+  ApplicationCommandOption,
+  Bot,
+  Interaction,
+} from "../../../deps.ts";
+import type { Command } from "../mod.ts";
+
+import type { Loggable } from "../../logger/mod.ts";
+
+import { ApplicationCommandTypes } from "../../../deps.ts";
+
+import * as startcmd from "./eventpoll_start.ts";
+import * as stopcmd from "./eventpoll_stop.ts";
+
+class EventPollCommand implements Command {
+  name: string;
+  description: string;
+  usage: string[];
+  options: ApplicationCommandOption[];
+  type: number;
+
+  private logger: Loggable;
+
+  constructor(logger: Loggable) {
+    this.name = "event-poll";
+    this.description = "poll a schedule of an event.";
+    this.usage = [
+      startcmd.usage,
+      stopcmd.usage,
+    ];
+    this.options = (startcmd.options).concat(stopcmd.options);
+    this.type = ApplicationCommandTypes.ChatInput;
+
+    this.logger = logger;
+  }
+
+  execute(_bot: Bot, _interaction: Interaction): void {
+    this.logger.debug("event-poll invoked!");
+  }
+}
+
+export { EventPollCommand };

--- a/src/command/eventpoll/eventpoll_start.ts
+++ b/src/command/eventpoll/eventpoll_start.ts
@@ -1,0 +1,54 @@
+import type { ApplicationCommandOption } from "../../../deps.ts";
+import { ApplicationCommandOptionTypes } from "../../../deps.ts";
+
+const usage = "/event-poll start title option1...";
+
+// /event-poll start ...
+const options: ApplicationCommandOption[] = [
+  {
+    name: "start",
+    description: "Start polling a schedule of an event.",
+    type: ApplicationCommandOptionTypes.SubCommand,
+    required: true,
+    options: [
+      {
+        name: "title",
+        description: "title of this poll",
+        type: ApplicationCommandOptionTypes.String,
+        required: true,
+      },
+      {
+        name: "option1",
+        description: "Candidate Event Time",
+        type: ApplicationCommandOptionTypes.String,
+        required: false,
+      },
+      {
+        name: "option2",
+        description: "Candidate Event Time",
+        type: ApplicationCommandOptionTypes.String,
+        required: false,
+      },
+      {
+        name: "option3",
+        description: "Candidate Event Time",
+        type: ApplicationCommandOptionTypes.String,
+        required: false,
+      },
+      {
+        name: "option4",
+        description: "Candidate Event Time",
+        type: ApplicationCommandOptionTypes.String,
+        required: false,
+      },
+      {
+        name: "option5",
+        description: "Candidate Event Time",
+        type: ApplicationCommandOptionTypes.String,
+        required: false,
+      },
+    ],
+  },
+];
+
+export { options, usage };

--- a/src/command/eventpoll/eventpoll_stop.ts
+++ b/src/command/eventpoll/eventpoll_stop.ts
@@ -1,0 +1,24 @@
+import type { ApplicationCommandOption } from "../../../deps.ts";
+import { ApplicationCommandOptionTypes } from "../../../deps.ts";
+
+const usage = "/event-poll stop id";
+
+// /event-poll stop ...
+const options: ApplicationCommandOption[] = [
+  {
+    name: "stop",
+    description: "Stop a poll with a poll id",
+    type: ApplicationCommandOptionTypes.SubCommand,
+    required: true,
+    options: [
+      {
+        name: "id",
+        description: "poll id",
+        type: ApplicationCommandOptionTypes.Number,
+        required: true,
+      },
+    ],
+  },
+];
+
+export { options, usage };

--- a/src/command/mod.ts
+++ b/src/command/mod.ts
@@ -1,0 +1,22 @@
+import type {
+  ApplicationCommandOption,
+  ApplicationCommandOptionTypes,
+  Bot,
+  Interaction,
+} from "../../deps.ts";
+
+export type subCommand = Omit<Command, "subcommands">;
+export type subCommandGroup = {
+  name: string;
+  subCommands: subCommand[];
+};
+
+export interface Command {
+  name: string;
+  description: string;
+  usage?: string[];
+  options?: ApplicationCommandOption[];
+  type: ApplicationCommandOptionTypes;
+  execute: (bot: Bot, interaction: Interaction) => unknown;
+  subcommands?: Array<subCommandGroup | subCommand>;
+}

--- a/src/event/handlers/guildCreate.ts
+++ b/src/event/handlers/guildCreate.ts
@@ -1,0 +1,13 @@
+import type { Bot, EventHandlers, Guild } from "../../../deps.ts";
+import type { Loggable } from "../../logger/mod.ts";
+
+// Create a handler which is invoked when this bot will join to a discord server(= guild).
+const guildCreateHandler = (
+  logger: Loggable,
+): EventHandlers["guildCreate"] => {
+  return (_bot: Bot, _guild: Guild): any => {
+    logger.debug("guildCreate");
+  };
+};
+
+export { guildCreateHandler };

--- a/src/event/handlers/mod.ts
+++ b/src/event/handlers/mod.ts
@@ -6,11 +6,13 @@ import { createEventHandlers } from "../../../deps.ts";
 // Load handlers statically.
 import { readyHandler } from "./ready.ts";
 import { messageCreateHandler } from "./messageCreate.ts";
+import { guildCreateHandler } from "./guildCreate.ts";
 
 const eventHandlers = (logger: Loggable): EventHandlers => {
   return createEventHandlers({
-    ready: readyHandler(logger),
+    guildCreate: guildCreateHandler(logger),
     messageCreate: messageCreateHandler(logger),
+    ready: readyHandler(logger),
   });
 };
 


### PR DESCRIPTION
# WHAT

- Register `/event-poll` slash command to the target guild (= discord server).

# WHY

- To make it usable in the specific discord server.
