### PR TITLE
fix severity comparison issue in logger

### DIFF
--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -116,7 +116,7 @@ class Logger {
 
   private shouldLog(severity: Severity): boolean {
     const v = severityToValue(severity);
-    return (this.severityValue >= v);
+    return (this.severityValue <= v);
   }
 
   private convertErr(err: Error): Record<string, unknown> {


### PR DESCRIPTION
# WHAT

- Fix severity comparison issue in Logger class.

# WHY

- to output log messages when the severity is higher than the logging severity, properly.
